### PR TITLE
[UX] improve structure hierarchy

### DIFF
--- a/symfony/bundles/sandbox-bundle/Manager/FixturesManager.php
+++ b/symfony/bundles/sandbox-bundle/Manager/FixturesManager.php
@@ -69,6 +69,7 @@ class FixturesManager
         }
 
         $structure = new Structure();
+        $structure->setPlatform($this->security->getPlatform());
         $structure->setName($name);
         $structure->setExternalId(Random::generate(8));
         $structure->setEnabled(true);

--- a/symfony/src/Form/Type/AudienceType.php
+++ b/symfony/src/Form/Type/AudienceType.php
@@ -248,15 +248,18 @@ class AudienceType extends AbstractType
     {
         // Retrieving structures hierarchy
         $hierarchyForUser = $this->structureManager->getStructureHierarchyForCurrentUser();
-        $hierarchy        = [];
+
+        $hierarchy = [];
         foreach ($hierarchyForUser as $row) {
             if (!array_key_exists($row['id'], $hierarchy)) {
                 $hierarchy[$row['id']] = [];
             }
 
             if ($row['child_id']) {
-                $hierarchy[$row['child_id']] = [];
-                $hierarchy[$row['id']][]     = $row['child_id'];
+                if (!array_key_exists($row['child_id'], $hierarchy)) {
+                    $hierarchy[$row['child_id']] = [];
+                }
+                $hierarchy[$row['id']][] = $row['child_id'];
             }
         }
 

--- a/symfony/templates/audience/audience_theme.html.twig
+++ b/symfony/templates/audience/audience_theme.html.twig
@@ -212,8 +212,10 @@
                                 <span class="slider"></span>
                             </label>
                             {% if has_children %}
-                                <a data-toggle="collapse" href="#container-children-{{ current }}">
+                                <a data-toggle="collapse" class="node-collapse-link" href="#container-children-{{ current }}">
                                     <label for="global-structure-{{ current }}">
+                                        <span id="arrow-open-{{ current }}">&#9658;</span>
+                                        <span id="arrow-close-{{ current }}" class="d-none">&#9660;</span>
                                         {{ information[current].name }} ({{ information[current].global_count }})
                                     </label>
                                 </a>
@@ -225,7 +227,7 @@
 
                             {# Slider body #}
                             {% if has_children %}
-                                <div id="container-children-{{ current }}" class="collapse structure-children">
+                                <div id="container-children-{{ current }}" data-current="{{ current }}" class="collapse structure-children">
                                     <div class="card card-body">
                                         <div>
                                             <label class="switch">
@@ -619,6 +621,18 @@
                 $('#choose-volunteer-lsit-edit').addClass('d-none');
             }
         });
+
+        $('.structure-children')
+                .on('show.bs.collapse', function () {
+                    var current = $(this).data('current');
+                    $('#arrow-open-' + current).addClass('d-none');
+                    $('#arrow-close-' + current).removeClass('d-none');
+                })
+                .on('hide.bs.collapse', function () {
+                    var current = $(this).data('current');
+                    $('#arrow-open-' + current).removeClass('d-none');
+                    $('#arrow-close-' + current).addClass('d-none');
+                });
 
     </script>
 


### PR DESCRIPTION
add arrows left to structure names when they have children
also fix a big issue used to create the original tree